### PR TITLE
Fix custom page size field in planner

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func buildPlanner(cfg PlannerConfig) error {
 			OrientationStr: "P",
 			UnitStr:        "pt",
 			Size: fpdf.SizeType{
-				Wd: 504, Hd: 672,
+				Wd: 504, Ht: 672,
 			},
 		})
 	default:


### PR DESCRIPTION
## Summary
- Correct custom page size height field to use Ht instead of Hd

## Testing
- `go run main.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68abf17a8bc88330ae870e110451c95b